### PR TITLE
fix: pin GitHub Actions to full commit SHAs

### DIFF
--- a/.github/workflows/autoreview.yml
+++ b/.github/workflows/autoreview.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Auto reviews branches
-        uses: golfzaptw/action-auto-reviews-from-branches@2.0.0
+        uses: golfzaptw/action-auto-reviews-from-branches@56292528010cf30b152738d99e2b6c9377b396ab # 2.0.0
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN}}
           EVENT_TYPE: APPROVE

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -20,5 +20,5 @@ jobs:
     container:
       image: returntocorp/semgrep
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
     - run: semgrep ci


### PR DESCRIPTION
Semgrep github-actions-mutable-action-tag: mutable tags/branches can be silently repointed by the action owner (supply-chain risk). Pin each uses: reference to its full 40-character commit SHA, with the previous tag preserved as a trailing comment.